### PR TITLE
Pullrequests/to/upstream/1

### DIFF
--- a/GameData/NearFutureAeronautics/Parts/Engine/Multimode/nfa-multimodal-25-1.cfg
+++ b/GameData/NearFutureAeronautics/Parts/Engine/Multimode/nfa-multimodal-25-1.cfg
@@ -102,8 +102,6 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
-			
 		}
 		running_open
 		{


### PR DESCRIPTION
Hi.

I'm nowadays running a cfg lint tool on anything that I use on my test beds before adding support on TweakScale, and the tool flagged this on one of your [config](https://github.com/ChrisAdderley/NearFutureAeronautics/blob/d727db574297cee252b652e4a378a6123a4fffba/GameData/NearFutureAeronautics/Parts/Engine/Multimode/nfa-multimodal-25-1.cfg#L105): a node with a name, but without a body:

```
		power_open
		{
			AUDIO
			{
				channel = Ship
				clip = NearFutureAeronautics/Sounds/broadswordclosed_loop
				volume = 0.0 0.0
				volume = 0.05 0.0
				volume = 0.7 1.0
				pitch = 0.0 0.2
				pitch = 1.0 1.0
				loop = true
			}
			MODEL_MULTI_PARTICLE  <--- HERE! This node has no body!
			
		}
		running_open
```

This, probably, is not relevant but since some time ago I'm trying to get rid of any... non-conformity... on configs and patches as the KSP behaviour is not exactly well defined when this happens (the problem on the Draining Valves the first time it appeared on KSP came to my mind).

However, I'm not aware of any collateral effect on removing that line - I did it on my test beds, and apparently nothing different happened. So perhaps you would like to check it on your test rig before accepting this? I'm not aware of any situation where a bodyless Node is useful, but absence of evidence is not evidence of absence.

Cheers.