### PR TITLE
Eeloo multi mode engine price adjustment

### DIFF
--- a/GameData/NearFutureAeronautics/Parts/Engine/Atomic/nfa-atomic-multimode-25-1.cfg
+++ b/GameData/NearFutureAeronautics/Parts/Engine/Atomic/nfa-atomic-multimode-25-1.cfg
@@ -35,7 +35,7 @@ PART
 	maxTemp = 2000 // = 3600
 	TechRequired = aerospaceTech
 	entryCost = 96000
-	cost = 24000
+	cost = 126500
 	category = Engine
 	subcategory = 0
 	title = #LOC_NearFutureAero_atomic-multimode-25-1_title


### PR DESCRIPTION
The current price for the nuclear multi-mode engine Eeloo is hilariously cheap (24,000). I propose changing it to 30k higher than the non-multi-mode nuclear engine. In other words, setting it at 126,500, though this can arguably be even higher.